### PR TITLE
Split up/down/left/right with `C-hjkl`.

### DIFF
--- a/pain_control.tmux
+++ b/pain_control.tmux
@@ -17,13 +17,9 @@ get_tmux_option() {
 
 pane_navigation_bindings() {
 	tmux bind-key h   select-pane -L
-	tmux bind-key C-h select-pane -L
 	tmux bind-key j   select-pane -D
-	tmux bind-key C-j select-pane -D
 	tmux bind-key k   select-pane -U
-	tmux bind-key C-k select-pane -U
 	tmux bind-key l   select-pane -R
-	tmux bind-key C-l select-pane -R
 }
 
 window_move_bindings() {
@@ -42,6 +38,10 @@ pane_resizing_bindings() {
 pane_split_bindings() {
 	tmux bind-key "|" split-window -h -c "#{pane_current_path}"
 	tmux bind-key "-" split-window -v -c "#{pane_current_path}"
+	tmux bind-key C-h split-window -h -c "#{pane_current_path}"\; swap-pane -U
+	tmux bind-key C-j split-window -v -c "#{pane_current_path}"
+	tmux bind-key C-k split-window -v -c "#{pane_current_path}"\; swap-pane -U
+	tmux bind-key C-l split-window -h -c "#{pane_current_path}"
 }
 
 improve_new_window_binding() {


### PR DESCRIPTION
I've actually always used `<prefix>+hjkl` for splitting in a direction, because [I have `C-hjkl` navigate panes without a prefix](https://github.com/rosshadden/dotfiles/blob/f4517676b74deb52ce79444f4547beee0fd376fd/src/.tmux.conf#L145-L152) which is so very convenient.

However, as this is a community project and I know not everyone else does that, I decided to make a pull request with `<prefix>+C-hjkl` splitting in a direction, and continue doing what I'm used to in another branch that I won't make a PR for.

Really what it comes down to is:

1) There's no reason to take up two key namespaces (`hjkl` and `C-hjkl`) for one thing (pane navigation).
2) Splitting in four directions (as opposed to the two directions currently accounted for in this repo) is just about necessary in many workflows, let alone useful.