### PR TITLE
Cycle through panes w/ prefix + C-j/ C-k

### DIFF
--- a/pain_control.tmux
+++ b/pain_control.tmux
@@ -16,14 +16,14 @@ get_tmux_option() {
 }
 
 pane_navigation_bindings() {
-	tmux bind-key h   select-pane -L
-	tmux bind-key C-h select-pane -L
-	tmux bind-key j   select-pane -D
-	tmux bind-key C-j select-pane -D
-	tmux bind-key k   select-pane -U
-	tmux bind-key C-k select-pane -U
-	tmux bind-key l   select-pane -R
-	tmux bind-key C-l select-pane -R
+	tmux bind-key    h   select-pane -L
+	tmux bind-key    C-h select-pane -L
+	tmux bind-key    j   select-pane -D
+	tmux bind-key -r C-j select-pane -t :.+
+	tmux bind-key    k   select-pane -U
+	tmux bind-key -r C-k select-pane -t :.-
+	tmux bind-key    l   select-pane -R
+	tmux bind-key    C-l select-pane -R
 }
 
 window_move_bindings() {


### PR DESCRIPTION
Basic scenario: one pane on left, two on the right. You want to move focus from left to bottom right.

Before: prefix + l, prefix + j

After: prefix + C-k

The more complicated the splitting is, the more I find this reduces keystrokes. Further, one may use it w/ -r because they are very unlikely to immediately type C-j/ C-k upon entering a pane (unlike j/k, which I often immediately use w/ vim).