### PR TITLE
Prevent EOL conversion on gif files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Force text files to have unix eols, so Windows/Cygwin does not break them
 *.* eol=lf
+*.gif -eol


### PR DESCRIPTION
The gif file 'screenshots/pane_resizing.gif' has a CRLF embedded in it, and this is driving git crazy. Whenever I have this repo checked out on my machine it constantly warns about performing the conversion and then pollutes my working directory with the change:

```
jsselman@dev:~/home/tmux/plugins/tmux-pain-control (master * u= origin/master)$ git status
# On branch master
# Changes not staged for commit:
#   (use "git add <file>..." to update what will be committed)
#   (use "git checkout -- <file>..." to discard changes in working directory)
#
#       modified:   screenshots/pane_resizing.gif
#
no changes added to commit (use "git add" and/or "git commit -a")
warning: CRLF will be replaced by LF in screenshots/pane_resizing.gif.
The file will have its original line endings in your working directory.
jsselman@dev:~/home/tmux/plugins/tmux-pain-control (master * u= origin/master)$ git checkout -- .gitattributes
warning: CRLF will be replaced by LF in screenshots/pane_resizing.gif.
The file will have its original line endings in your working directory.
jsselman@dev:~/home/tmux/plugins/tmux-pain-control (master * u= origin/master)$ git status
# On branch master
# Changes not staged for commit:
#   (use "git add <file>..." to update what will be committed)
#   (use "git checkout -- <file>..." to discard changes in working directory)
#
#       modified:   screenshots/pane_resizing.gif
#
no changes added to commit (use "git add" and/or "git commit -a")
warning: CRLF will be replaced by LF in screenshots/pane_resizing.gif.
The file will have its original line endings in your working directory.
```

This commit merely disables this behavior for gif files.
