### PR TITLE
Denote gif as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Force text files to have unix eols, so Windows/Cygwin does not break them
 *.* eol=lf
+
+*.gif binary


### PR DESCRIPTION
Ensure that git does not convert CRLF to LF in screenshot gifs on Linux and
OSX.
