### PR TITLE
Add support for full width splits.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ The amount of cells to resize can be configured with `@pane_resize` option. See
   split current pane horizontally
 - `prefix + -`<br/>
   split current pane vertically
+- `prefix + \`<br/>
+  split current pane full width horizontally
+- `prefix + _`<br/>
+  split current pane full width vertically
 
 Newly created pane always has the same path as the original pane.
 

--- a/pain_control.tmux
+++ b/pain_control.tmux
@@ -41,7 +41,9 @@ pane_resizing_bindings() {
 
 pane_split_bindings() {
 	tmux bind-key "|" split-window -h -c "#{pane_current_path}"
+	tmux bind-key "\\" split-window -fh -c "#{pane_current_path}"
 	tmux bind-key "-" split-window -v -c "#{pane_current_path}"
+	tmux bind-key "_" split-window -fv -c "#{pane_current_path}"
 	tmux bind-key "%" split-window -h -c "#{pane_current_path}"
 	tmux bind-key '"' split-window -v -c "#{pane_current_path}"
 }


### PR DESCRIPTION
This feature is new in tmux 2.3.  It allows the user to split a pane,
but doing it across the full-width of the window.