### PR TITLE
allow disabling current pane path as new windows starting path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### master
 - update readme - write all keybindings
 - override default split window key bindings
+- added "@new_window_path" to allow disabling using the panes current path as
+  the new windows starting path
 
 ### v1.0.0, 2014-08-30
 - update readme to reflect github organization change

--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ Example:
 
     set-option -g @pane_resize "10"
 
+
+You can set `@new_window_path` Tmux option to false to disable creation of new windows with the starting path of the current pane. "true" is the default.
+
+Example:
+
+    set-option -g @new_window_path "false"
+
 ### Other plugins
 
 You might also find these useful:

--- a/pain_control.tmux
+++ b/pain_control.tmux
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 default_pane_resize="5"
+default_new_window_path="true"
 
 # tmux show-option "q" (quiet) flag does not set return value to 1, even though
 # the option does not exist. This function patches that.
@@ -49,7 +50,11 @@ pane_split_bindings() {
 }
 
 improve_new_window_binding() {
-	tmux bind-key "c" new-window -c "#{pane_current_path}"
+	local args=()
+	if [ $(get_tmux_option "@new_window_path" "$default_new_window_path") = "true" ]; then
+		args=(-c "#{pane_current_path}")
+	fi
+	tmux bind-key "c" new-window "${args[@]}"
 }
 
 main() {


### PR DESCRIPTION
added "@new_window_path" to allow disabling using the panes current path as the new windows starting path