### PR TITLE
Fix "resizing panes" up & down key mappings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ a better binding for that, `prefix + a` (if your prefix is `C-a`).
 - `prefix + shift + h`<br/>
   resize current pane 5 cells to the left
 - `prefix + shift + j`<br/>
-  resize 5 cells in the up direction
-- `prefix + shift + k`<br/>
   resize 5 cells in the down direction
+- `prefix + shift + k`<br/>
+  resize 5 cells in the up direction
 - `prefix + shift + l`<br/>
   resize 5 cells to the right
 


### PR DESCRIPTION
Currently the README says that `prefix + shift + j` expands the current pane up and `prefix + shift + k` expands it down; it should be the other way around.