### PR TITLE
docs(readme): fix pane sizing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ The amount of cells to resize can be configured with `@pane_resize` option. See
 **Splitting panes**
 
 - `prefix + |`<br/>
-  split current pane horizontally
-- `prefix + -`<br/>
   split current pane vertically
+- `prefix + -`<br/>
+  split current pane horizontally
 - `prefix + \`<br/>
-  split current pane full width horizontally
-- `prefix + _`<br/>
   split current pane full width vertically
+- `prefix + _`<br/>
+  split current pane full width horizontally
 
 Newly created pane always has the same path as the original pane.
 


### PR DESCRIPTION
There were discrepancies between the pane sizing actions and their associated action descriptions.
For example:
    `prefix + |`
    - split pane ~~horizontally~~ -> **vertically**