### PR TITLE
Change "c" new-window behaviour

### DIFF
--- a/pain_control.tmux
+++ b/pain_control.tmux
@@ -49,9 +49,8 @@ pane_split_bindings() {
 }
 
 improve_new_window_binding() {
-	tmux bind-key "c" new-window -ac "#{pane_current_path}"
-	tmux bind-key "C" new-window -c "#{pane_current_path}"
-
+	tmux bind-key "c" new-window -c "#{pane_current_path}"
+	tmux bind-key "e" new-window -ac "#{pane_current_path}" # new-window (hEre)
 }
 
 main() {

--- a/pain_control.tmux
+++ b/pain_control.tmux
@@ -49,7 +49,9 @@ pane_split_bindings() {
 }
 
 improve_new_window_binding() {
-	tmux bind-key "c" new-window -c "#{pane_current_path}"
+	tmux bind-key "c" new-window -ac "#{pane_current_path}"
+	tmux bind-key "C" new-window -c "#{pane_current_path}"
+
 }
 
 main() {


### PR DESCRIPTION
I often prefer the new window to be created after the current one. I suggest to change the default "c" behaviour to reflect this action and to add "C" to create a new window at the end of the list.
It's easy to think of "c" as "light action" (create here) and "C" as "strong action" (create there, push the new window far).