### PR TITLE
Restore the old `swap-window` behavior (`<` and `>` key bindings)

### DIFF
--- a/pain_control.tmux
+++ b/pain_control.tmux
@@ -27,8 +27,8 @@ pane_navigation_bindings() {
 }
 
 window_move_bindings() {
-	tmux bind-key -r "<" swap-window -t -1
-	tmux bind-key -r ">" swap-window -t +1
+	tmux bind-key -r "<" swap-window -d -t -1
+	tmux bind-key -r ">" swap-window -d -t +1
 }
 
 pane_resizing_bindings() {


### PR DESCRIPTION
Tmux changed the behavior of `swap-window` to keep the focus instead of following the swapped window (s. [tmux issue 1879](https://github.com/tmux/tmux/issues/1879)). This commit adds the `-d` switch to `swap-window` bindings to restore the old behavior.