### PR TITLE
Make pane navigation bindings repeatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Notice most of the bindings emulate vim cursor movements.
 - `prefix + l` and `prefix + C-l`<br/>
   select pane on the right
 
+These mappings are `repeatable`.
+
 <br/>
 
 **Note**: This overrides tmux's default binding for toggling between last

--- a/pain_control.tmux
+++ b/pain_control.tmux
@@ -16,14 +16,14 @@ get_tmux_option() {
 }
 
 pane_navigation_bindings() {
-	tmux bind-key h   select-pane -L
-	tmux bind-key C-h select-pane -L
-	tmux bind-key j   select-pane -D
-	tmux bind-key C-j select-pane -D
-	tmux bind-key k   select-pane -U
-	tmux bind-key C-k select-pane -U
-	tmux bind-key l   select-pane -R
-	tmux bind-key C-l select-pane -R
+	tmux bind-key -r h   select-pane -L
+	tmux bind-key -r C-h select-pane -L
+	tmux bind-key -r j   select-pane -D
+	tmux bind-key -r C-j select-pane -D
+	tmux bind-key -r k   select-pane -U
+	tmux bind-key -r C-k select-pane -U
+	tmux bind-key -r l   select-pane -R
+	tmux bind-key -r C-l select-pane -R
 }
 
 window_move_bindings() {


### PR DESCRIPTION
Currently the pane navigation keybindings are not repeatable so the prefix key needs to be triggered before each consecutive pane switch.
This PR makes the pane navigation keybindings repeatable.

Closes #27 