### PR TITLE
Improve window move bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Newly created pane always has the same path as the original pane.
 - `prefix + <` - moves current window one position to the left
 - `prefix + >` - moves current window one position to the right
 
+These mappings are `repeatable`.
+
 ### Installation with [Tmux Plugin Manager](https://github.com/tmux-plugins/tpm) (recommended)
 
 Add plugin to the list of TPM plugins in `.tmux.conf`:

--- a/pain_control.tmux
+++ b/pain_control.tmux
@@ -27,8 +27,8 @@ pane_navigation_bindings() {
 }
 
 window_move_bindings() {
-	tmux bind-key -r "<" swap-window -t -1
-	tmux bind-key -r ">" swap-window -t +1
+	tmux bind-key -r "<" swap-window -d -t -1
+	tmux bind-key -r ">" swap-window -d -t +1
 }
 
 pane_resizing_bindings() {

--- a/pain_control.tmux
+++ b/pain_control.tmux
@@ -29,7 +29,7 @@ pane_navigation_bindings() {
 window_move_bindings() {
 	# V3.0 changed the way tmux handles focus in swap-window. -d is now
 	# required to keep focus on the current window.
-	if [ "$(tmux -V | cut -d' ' -f2)" ">" 3.0 ]; then
+	if (( $(echo "$(tmux -V | grep -Eo "[0-9]+\.[0-9]+") >= 3.0" | bc -l) )); then
 		tmux bind-key -r "<" swap-window -d -t -1
 		tmux bind-key -r ">" swap-window -d -t +1
 	else

--- a/pain_control.tmux
+++ b/pain_control.tmux
@@ -27,8 +27,15 @@ pane_navigation_bindings() {
 }
 
 window_move_bindings() {
-	tmux bind-key -r "<" swap-window -d -t -1
-	tmux bind-key -r ">" swap-window -d -t +1
+	# V3.0 changed the way tmux handles focus in swap-window. -d is now
+	# required to keep focus on the current window.
+	if [ "$(tmux -V | cut -d' ' -f2)" ">" 3.0 ]; then
+		tmux bind-key -r "<" swap-window -d -t -1
+		tmux bind-key -r ">" swap-window -d -t +1
+	else
+		tmux bind-key -r "<" swap-window -t -1
+		tmux bind-key -r ">" swap-window -t +1
+	fi
 }
 
 pane_resizing_bindings() {


### PR DESCRIPTION
Currently the window move bindings switch focus from the current window to the one we are swapping with our current window. This makes the bindings somewhat unintuitive.

For example, if I'm in a session with 3 windows and the third one is currently focused:

```
1:A 2:B 3:C*
```

I would expect that triggering `` `prefix + <` (moves current window one position to the left)`` twice would move window C to the first position:

```
1:C* 2:A 3:B
```

### Current behaviour

![current behaviour](https://user-images.githubusercontent.com/19822240/71937902-7120b800-31b6-11ea-83ac-dcf90115b185.gif)

The first time the binding is triggered it swaps windows C and B, but it moves focus from C to B

```
1:A 2:C 3:B*
```

The second time it swaps the same windows (B and C), but it focuses window C, which brings us back to the initial position:

```
1:A 2:B 3:C*
```

### New behaviour

This PR changes the bindings to keep focus on the window being moved, which solves the issue

![new behaviour](https://user-images.githubusercontent.com/19822240/71937898-6ebe5e00-31b6-11ea-893d-26dae9969935.gif)


