### PR TITLE
Allow disabling one or more bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,17 @@ Example:
 
     set-option -g @pane_resize "10"
 
+To disable certain keys from being mapped by this plugin you can set
+`@disabled_keys` to a comma-separated list of keys. It is empty by default, ie.
+all keys will be mapped.
+
+Examples:
+
+    # Disable | mapping
+    set-options -g @disabled_keys "|"
+    # Disable mapping of H, J, K and L
+    set-options -g @disabled_keys "H,J,K,L"
+
 ### Other plugins
 
 You might also find these useful:

--- a/pain_control.tmux
+++ b/pain_control.tmux
@@ -15,41 +15,63 @@ get_tmux_option() {
 	fi
 }
 
+bind_key() {
+  local disabled_keys
+  local dis_key
+  local key
+
+  key="$1"
+
+  disabled_keys=$(get_tmux_option "@disabled_keys" "")
+  # comma-separated list to array
+  IFS=',' read -r -a disabled_keys <<< "$disabled_keys"
+
+  for dis_key in "${disabled_keys[@]}"
+  do
+    if [[ "$dis_key" == "$key" ]]
+    then
+      # The user disabled the mapping of this key
+      return
+    fi
+  done
+	bind_key "$@"
+}
+
 pane_navigation_bindings() {
-	tmux bind-key h   select-pane -L
-	tmux bind-key C-h select-pane -L
-	tmux bind-key j   select-pane -D
-	tmux bind-key C-j select-pane -D
-	tmux bind-key k   select-pane -U
-	tmux bind-key C-k select-pane -U
-	tmux bind-key l   select-pane -R
-	tmux bind-key C-l select-pane -R
+	bind_key h   select-pane -L
+	bind_key C-h select-pane -L
+	bind_key j   select-pane -D
+	bind_key C-j select-pane -D
+	bind_key k   select-pane -U
+	bind_key C-k select-pane -U
+	bind_key l   select-pane -R
+	bind_key C-l select-pane -R
 }
 
 window_move_bindings() {
-	tmux bind-key -r "<" swap-window -d -t -1
-	tmux bind-key -r ">" swap-window -d -t +1
+	bind_key -r "<" swap-window -d -t -1
+	bind_key -r ">" swap-window -d -t +1
 }
 
 pane_resizing_bindings() {
 	local pane_resize=$(get_tmux_option "@pane_resize" "$default_pane_resize")
-	tmux bind-key -r H resize-pane -L "$pane_resize"
-	tmux bind-key -r J resize-pane -D "$pane_resize"
-	tmux bind-key -r K resize-pane -U "$pane_resize"
-	tmux bind-key -r L resize-pane -R "$pane_resize"
+	bind_key -r H resize-pane -L "$pane_resize"
+	bind_key -r J resize-pane -D "$pane_resize"
+	bind_key -r K resize-pane -U "$pane_resize"
+	bind_key -r L resize-pane -R "$pane_resize"
 }
 
 pane_split_bindings() {
-	tmux bind-key "|" split-window -h -c "#{pane_current_path}"
-	tmux bind-key "\\" split-window -fh -c "#{pane_current_path}"
-	tmux bind-key "-" split-window -v -c "#{pane_current_path}"
-	tmux bind-key "_" split-window -fv -c "#{pane_current_path}"
-	tmux bind-key "%" split-window -h -c "#{pane_current_path}"
-	tmux bind-key '"' split-window -v -c "#{pane_current_path}"
+	bind_key "|" split-window -h -c "#{pane_current_path}"
+	bind_key "\\" split-window -fh -c "#{pane_current_path}"
+	bind_key "-" split-window -v -c "#{pane_current_path}"
+	bind_key "_" split-window -fv -c "#{pane_current_path}"
+	bind_key "%" split-window -h -c "#{pane_current_path}"
+	bind_key '"' split-window -v -c "#{pane_current_path}"
 }
 
 improve_new_window_binding() {
-	tmux bind-key "c" new-window -c "#{pane_current_path}"
+	bind_key "c" new-window -c "#{pane_current_path}"
 }
 
 main() {


### PR DESCRIPTION
I wanted to disable a single keybinding and there was no way to do so. So I implemented one.

This PR adds a new config variable:

```
set-option -g @disabled_keys "H,J,K,L"
```

where `H`, `J`, `K` and `L`  are bindings that this plugin would override.
Setting it like so would effectively not call `tmux bind-key` for these keys.