### PR TITLE
Use Alt-arrow keys without prefix key to switch panes

### DIFF
--- a/pain_control.tmux
+++ b/pain_control.tmux
@@ -53,13 +53,18 @@ pane_split_bindings() {
 	tmux bind-key "%" split-window -h -c "#{pane_current_path}"
 	tmux bind-key '"' split-window -v -c "#{pane_current_path}"
 }
+pane_break_bindings(){
+	tmux bind-key j command-prompt -p "join pane from:"  "join-pane -s '%%'"
+	tmux bind-key s command-prompt -p "send pane to:"  "join-pane -t '%%'"
 
+}
 improve_new_window_binding() {
 	tmux bind-key "c" new-window -c "#{pane_current_path}"
 	tmux bind-key C-c new-session
 }
 
 main() {
+	pane_break_bindings
 	pane_navigation_bindings
 	window_move_bindings
 	pane_resizing_bindings

--- a/pain_control.tmux
+++ b/pain_control.tmux
@@ -56,6 +56,7 @@ pane_split_bindings() {
 
 improve_new_window_binding() {
 	tmux bind-key "c" new-window -c "#{pane_current_path}"
+	tmux bind-key C-c new-session
 }
 
 main() {

--- a/pain_control.tmux
+++ b/pain_control.tmux
@@ -53,11 +53,7 @@ pane_split_bindings() {
 	tmux bind-key "%" split-window -h -c "#{pane_current_path}"
 	tmux bind-key '"' split-window -v -c "#{pane_current_path}"
 }
-pane_break_bindings(){
-	tmux bind-key j command-prompt -p "join pane from:"  "join-pane -s '%%'"
-	tmux bind-key s command-prompt -p "send pane to:"  "join-pane -t '%%'"
 
-}
 improve_new_window_binding() {
 	tmux bind-key "c" new-window -c "#{pane_current_path}"
 	tmux bind-key C-c new-session

--- a/pain_control.tmux
+++ b/pain_control.tmux
@@ -60,7 +60,6 @@ improve_new_window_binding() {
 }
 
 main() {
-	pane_break_bindings
 	pane_navigation_bindings
 	window_move_bindings
 	pane_resizing_bindings

--- a/pain_control.tmux
+++ b/pain_control.tmux
@@ -24,6 +24,12 @@ pane_navigation_bindings() {
 	tmux bind-key C-k select-pane -U
 	tmux bind-key l   select-pane -R
 	tmux bind-key C-l select-pane -R
+	
+	# Use Alt-arrow keys without prefix key to switch panes
+	tmux bind -n M-Left select-pane -L
+	tmux bind -n M-Right select-pane -R
+	tmux bind -n M-Up select-pane -U
+	tmux bind -n M-Down select-pane -D
 }
 
 window_move_bindings() {


### PR DESCRIPTION
Use Alt-arrow keys without prefix key to switch panes, 
sourced from https://gist.github.com/spicycode/1229612 